### PR TITLE
fix encoding detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ deflate = ["async-compression/deflate"]
 async-compression = { version = "0.3", features = ["futures-bufread"] }
 futures-util = { version = "0.3", features = ["io"] }
 regex = "1.3"
-tide = "0.10"
+tide = "0.11"
 
 [dev-dependencies]
 async-h1 = "2.0"

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -115,21 +115,21 @@ fn accepts_encoding<State: Send + Sync + 'static>(req: &Request<State>) -> Optio
 
     #[cfg(feature = "brotli")]
     {
-        if header.iter().any(|v| v.as_str() == "br") {
+        if header.iter().any(|v| v.as_str().contains("br")) {
             return Some(Encoding::BROTLI);
         }
     }
 
     #[cfg(feature = "gzip")]
     {
-        if header.iter().any(|v| v.as_str() == "gzip") {
+        if header.iter().any(|v| v.as_str().contains("gzip")) {
             return Some(Encoding::GZIP);
         }
     }
 
     #[cfg(feature = "deflate")]
     {
-        if header.iter().any(|v| v.as_str() == "deflate") {
+        if header.iter().any(|v| v.as_str().contains("deflate")) {
             return Some(Encoding::DEFLATE);
         }
     }


### PR DESCRIPTION
thought not robust as the first sense, it should be okay to use `contains` to workaround the problem