### PR TITLE
src: export as Compress

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Outgoing compression middleware for the [Tide][] web framework.
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     let mut app = tide::new();
-    app.with(tide_compress::CompressMiddleware::new());
+    app.with(tide_compress::Compress::new());
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 mod middleware;
 
-pub use middleware::CompressMiddleware;
+pub use middleware::Compress;
 
 #[derive(PartialEq)]
 pub enum Encoding {

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -15,38 +15,38 @@ const THRESHOLD: usize = 1024;
 
 /// A middleware for compressing response body data.
 #[derive(Clone, Debug)]
-pub struct CompressMiddleware {
+pub struct Compress {
     threshold: usize,
 }
 
-impl Default for CompressMiddleware {
+impl Default for Compress {
     fn default() -> Self {
-        CompressMiddleware {
+        Self {
             threshold: THRESHOLD,
         }
     }
 }
 
-impl CompressMiddleware {
-    /// Creates a new CompressMiddleware.
+impl Compress {
+    /// Creates a new Compress middleware.
     ///
     /// Uses the default minimum body size threshold (1024 bytes).
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Creates a new CompressMiddleware with a custom minimum body size threshold.
+    /// Creates a new Compress middleware with a custom minimum body size threshold.
     ///
     /// # Arguments
     ///
     /// * `threshold` - minimum body size in bytes.
     pub fn with_threshold(threshold: usize) -> Self {
-        CompressMiddleware { threshold }
+        Compress { threshold }
     }
 }
 
 #[tide::utils::async_trait]
-impl<State: Clone + Send + Sync + 'static> Middleware<State> for CompressMiddleware {
+impl<State: Clone + Send + Sync + 'static> Middleware<State> for Compress {
     async fn handle(&self, req: Request<State>, next: Next<'_, State>) -> tide::Result {
         // Incoming Request data
         // Need to grab these things before the request is consumed by `next.run()`.

--- a/tests/compressed.rs
+++ b/tests/compressed.rs
@@ -1,5 +1,6 @@
 use tide::http::{headers, Method, Request, StatusCode, Url};
 use tide::Response;
+use tide_compress::Compress;
 
 const TEXT: &'static str = concat![
     "Chunk one\n",
@@ -21,7 +22,7 @@ const BR_COMPRESSED: &'static [u8] = &[
 #[async_std::test]
 async fn brotli_compressed() {
     let mut app = tide::new();
-    app.with(tide_compress::CompressMiddleware::with_threshold(16));
+    app.with(Compress::with_threshold(16));
     app.at("/").get(|_| async {
         let mut res = Response::new(StatusCode::Ok);
         res.set_body(TEXT.to_owned());
@@ -66,7 +67,7 @@ const GZIPPED: &'static [u8] = &[
 #[async_std::test]
 async fn gzip_compressed() {
     let mut app = tide::new();
-    app.with(tide_compress::CompressMiddleware::with_threshold(16));
+    app.with(Compress::with_threshold(16));
     app.at("/").get(|_| async move {
         let mut res = Response::new(StatusCode::Ok);
         res.set_body(TEXT.to_owned());
@@ -95,7 +96,7 @@ const DEFLATED: &'static [u8] = &[
 #[async_std::test]
 async fn deflate_compressed() {
     let mut app = tide::new();
-    app.with(tide_compress::CompressMiddleware::with_threshold(16));
+    app.with(Compress::with_threshold(16));
     app.at("/").get(|_| async {
         let mut res = Response::new(StatusCode::Ok);
         res.set_body(TEXT.to_owned());

--- a/tests/existing-encoding.rs
+++ b/tests/existing-encoding.rs
@@ -1,5 +1,6 @@
 use tide::http::{headers, Method, Request, StatusCode, Url};
 use tide::Response;
+use tide_compress::Compress;
 
 const TEXT: &'static str = concat![
     "Chunk one\n",
@@ -15,7 +16,7 @@ const TEXT: &'static str = concat![
 #[async_std::test]
 async fn existing_encoding() {
     let mut app = tide::new();
-    app.with(tide_compress::CompressMiddleware::with_threshold(16));
+    app.with(Compress::with_threshold(16));
     app.at("/").get(|_| async {
         let mut res = Response::new(StatusCode::Ok);
         res.set_body(TEXT.to_owned());
@@ -36,7 +37,7 @@ async fn existing_encoding() {
 #[async_std::test]
 async fn multi_existing_encoding() {
     let mut app = tide::new();
-    app.with(tide_compress::CompressMiddleware::with_threshold(16));
+    app.with(Compress::with_threshold(16));
     app.at("/").get(|_| async {
         let mut res = Response::new(StatusCode::Ok);
         res.set_body(TEXT.to_owned());

--- a/tests/unencoded.rs
+++ b/tests/unencoded.rs
@@ -1,5 +1,6 @@
 use tide::http::{headers, Method, Request, StatusCode, Url};
 use tide::Response;
+use tide_compress::Compress;
 
 const TEXT: &'static str = concat![
     "Chunk one\n",
@@ -15,7 +16,7 @@ const TEXT: &'static str = concat![
 #[async_std::test]
 async fn no_accepts_encoding() {
     let mut app = tide::new();
-    app.with(tide_compress::CompressMiddleware::with_threshold(16));
+    app.with(Compress::with_threshold(16));
     app.at("/").get(|_| async {
         let mut res = Response::new(StatusCode::Ok);
         res.set_body(TEXT.to_owned());
@@ -34,7 +35,7 @@ async fn no_accepts_encoding() {
 #[async_std::test]
 async fn invalid_accepts_encoding() {
     let mut app = tide::new();
-    app.with(tide_compress::CompressMiddleware::with_threshold(16));
+    app.with(Compress::with_threshold(16));
     app.at("/").get(|_| async {
         let mut res = Response::new(StatusCode::Ok);
         res.set_body(TEXT.to_owned());
@@ -54,7 +55,7 @@ async fn invalid_accepts_encoding() {
 #[async_std::test]
 async fn head_request() {
     let mut app = tide::new();
-    app.with(tide_compress::CompressMiddleware::with_threshold(16));
+    app.with(Compress::with_threshold(16));
     app.at("/").get(|_| async {
         let mut res = Response::new(StatusCode::Ok);
         res.set_body(TEXT.to_owned());
@@ -77,7 +78,7 @@ async fn head_request() {
 #[async_std::test]
 async fn below_threshold_request() {
     let mut app = tide::new();
-    app.with(tide_compress::CompressMiddleware::new());
+    app.with(Compress::new());
     app.at("/").get(|_| async {
         let mut res = Response::new(StatusCode::Ok);
         res.set_body(TEXT.to_owned());
@@ -100,7 +101,7 @@ async fn below_threshold_request() {
 #[async_std::test]
 async fn cache_control() {
     let mut app = tide::new();
-    app.with(tide_compress::CompressMiddleware::with_threshold(16));
+    app.with(Compress::with_threshold(16));
     app.at("/").get(|_| async {
         let mut res = Response::new(StatusCode::Ok);
         res.set_body(TEXT.to_owned());


### PR DESCRIPTION
Rather than CompressMiddleware.

I am not really convinced the extra verbosity adds anything here.