### PR TITLE
Fix handling Accept-Encoding: identity

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -189,7 +189,14 @@ impl<State: Clone + Send + Sync + 'static> Middleware<State> for CompressMiddlew
             Encoding::Gzip,
             #[cfg(feature = "deflate")]
             Encoding::Deflate,
+            Encoding::Identity,
         ])?;
+
+        if encoding == Encoding::Identity {
+            res.remove_header(headers::CONTENT_ENCODING);
+            res.set_body(body);
+            return Ok(res);
+        }
 
         // Get a new Body backed by an appropriate encoder, if one is available.
         res.set_body(get_encoder(body, &encoding));


### PR DESCRIPTION
- https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-encoding.
- Content-Encoding should not supply when the request header field has the Accept-Encoding: identity.